### PR TITLE
chore: update codeowners and add auto-assign PR to author workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # Every file in the repo is assigned to the lead developer.
 
-- @hbuie112358
+- @hb-des-00

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-# Architecture: Auto-Assignment for Source-of-Truth
-
-# Every file in the repo is assigned to the lead developer.
+# Show this developer as code owner so they will be assigned as reviewer for all pull requests
 
 - @hb-des-00

--- a/.github/workflows/auto-assign-pr-to-author.yml
+++ b/.github/workflows/auto-assign-pr-to-author.yml
@@ -1,0 +1,22 @@
+name: Auto Assign PR Creator
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign PR to author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.pull_request.user.login]
+            })


### PR DESCRIPTION
# Description

changed codeowners file to auto-assign developer for review and auto-assign the pr to the developer who opened it.
